### PR TITLE
Style: update dark color for Button UI

### DIFF
--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -1,0 +1,41 @@
+html {
+  /* Add c(conventional) prefix to all colors to avoid conflicts with other styles */
+
+  /* Light mode colors */
+  --c-background-color: var(--bgColor-default, #ffffff);
+  --c-border-color: var(--borderColor-default, #d0d7de);
+  --c-text-color: var(--fgColor-default, #1f2328);
+  --c-shadow-color: var(--color-shadow-medium, rgba(140, 149, 159, 0.2));
+  --c-active-color: var(--bgColor-accent-emphasis, #0969da);
+  --c-active-text-color: var(--fgColor-onEmphasis, #ffffff);
+  --c-hover-color: var(--control-bgColor-hover, #f6f8fa);
+  --c-button-bg-color: var(--control-bgColor-rest, #f3f4f6);
+  --c-button-hover-bg-color: var(--control-bgColor-hover, #e5e7eb);
+  --c-button-text-color: var(--fgColor-muted, #374151);
+  --c-button-active-bg-color: var(--bgColor-accent-muted, #dbeafe);
+  --c-button-active-text-color: var(--fgColor-accent, #1e40af);
+  --c-breadcrumb-bg-color: var(--bgColor-accent-muted, #dbeafe);
+  --c-breadcrumb-hover-bg-color: var(--bgColor-accent-subtle, #bfdbfe);
+  --c-breadcrumb-text-color: var(--fgColor-accent, #1e40af);
+  --c-breadcrumb-separator-color: var(--fgColor-muted, #9ca3af);
+}
+
+/* Dark mode colors */
+html[data-color-mode="dark"] {
+  --c-background-color: var(--bgColor-default, #0d1117);
+  --c-border-color: var(--borderColor-default, #30363d);
+  --c-text-color: var(--fgColor-default, #e6edf3);
+  --c-shadow-color: var(--color-shadow-medium, rgba(1, 4, 9, 0.8));
+  --c-active-color: var(--bgColor-accent-emphasis, #1f6feb);
+  --c-active-text-color: var(--fgColor-onEmphasis, #ffffff);
+  --c-hover-color: var(--control-bgColor-hover, #21262d);
+  --c-button-bg-color: var(--control-bgColor-rest, #212830);
+  --c-button-hover-bg-color: var(--control-bgColor-hover, #262c36);
+  --c-button-text-color: var(--fgColor-muted, #9198a1);
+  --c-button-active-bg-color: var(--bgColor-accent-muted, #388bfd1a);
+  --c-button-active-text-color: var(--fgColor-accent, #4493f8);
+  --c-breadcrumb-bg-color: var(--bgColor-accent-muted, #388bfd1a);
+  --c-breadcrumb-hover-bg-color: var(--bgColor-accent-subtle, #3a8cfd5c);
+  --c-breadcrumb-text-color: var(--fgColor-accent, #4493f8);
+  --c-breadcrumb-separator-color: var(--fgColor-muted, #656c76);
+}

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -1,25 +1,4 @@
-html {
-  /* Add c(conventional) prefix to all colors to avoid conflicts with other styles */
-  /* Light mode colors */
-  --c-background-color: #ffffff;
-  --c-border-color: #d0d7de;
-  --c-text-color: #1f2328;
-  --c-shadow-color: rgba(140, 149, 159, 0.2);
-  --c-active-color: #0969da;
-  --c-active-text-color: #ffffff;
-  --c-hover-color: #f6f8fa;
-}
-
-/* Dark mode colors ! */
-html[data-color-mode="dark"] {
-  --c-background-color: #161b22;
-  --c-border-color: #30363d;
-  --c-text-color: #e6edf3;
-  --c-shadow-color: rgba(1, 4, 9, 0.8);
-  --c-active-color: #1f6feb;
-  --c-active-text-color: #ffffff;
-  --c-hover-color: #21262d;
-}
+@use "./global";
 
 #conventional-comment-popup {
   position: absolute;
@@ -64,17 +43,12 @@ html[data-color-mode="dark"] {
 }
 
 .cc-wrapper {
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--c-border-color);
   border-radius: 6px;
-  background-color: #ffffff;
+  background-color: var(--c-background-color);
   display: flex;
   flex-direction: column;
   position: relative;
-
-  &:focus-within {
-    border-color: #2563eb;
-    box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.2);
-  }
 }
 
 .cc-editor-enhanced {
@@ -95,7 +69,7 @@ html[data-color-mode="dark"] {
 
 #conventional-comment-button-bar {
   padding: 8px;
-  border-bottom: 1px solid #e5e7eb;
+  border-bottom: 1px solid var(--c-border-color);
   margin-bottom: 4px;
 
   .cc-buttons-container {
@@ -106,37 +80,37 @@ html[data-color-mode="dark"] {
   }
 
   .cc-button {
-    background-color: #f3f4f6;
+    background-color: var(--c-button-bg-color);
     border: none;
     border-radius: 9999px;
     padding: 4px 12px;
     font-size: 12px;
     font-weight: 500;
-    color: #374151;
+    color: var(--c-button-text-color);
     cursor: pointer;
     transition: background-color 0.2s ease-in-out;
 
     &:hover {
-      background-color: #e5e7eb;
+      background-color: var(--c-button-hover-bg-color);
     }
 
     &.active {
-      background-color: #dbeafe;
-      color: #1e40af;
+      background-color: var(--c-button-active-bg-color);
+      color: var(--c-button-active-text-color);
       font-weight: 600;
     }
   }
 
   .cc-breadcrumb {
-    background-color: #dbeafe;
-    color: #1e40af;
+    background-color: var(--c-breadcrumb-bg-color);
+    color: var(--c-breadcrumb-text-color);
     &:hover {
-      background-color: #bfdbfe;
+      background-color: var(--c-breadcrumb-hover-bg-color);
     }
   }
 
   .cc-breadcrumb-separator {
-    color: #9ca3af;
+    color: var(--c-breadcrumb-separator-color);
     margin: 0 2px;
     font-size: 14px;
   }


### PR DESCRIPTION
## Description

This PR introduces the following changes:
- Split colors into a new file
- Support dark mode for Button UI
- Uses colors from GitHub, with the current color as a fallback

## Screenshots

### Dark mode
<img width="794" height="301" alt="image" src="https://github.com/user-attachments/assets/feac6570-d789-486e-afc6-90408ee28ae1" />

### Light mode
<img width="801" height="298" alt="image" src="https://github.com/user-attachments/assets/cf7b8915-d992-44fe-9ef5-88ccac74cd0c" />