### PR TITLE
Enhancement: Enhance UX and type

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "gulp-sass": "^5.1.0",
     "gulp-sourcemaps": "^2.6.5",
     "sass": "^1.70.0",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "merge-stream": "^2.0.0"
   }
 }

--- a/src/buttonHandler.ts
+++ b/src/buttonHandler.ts
@@ -1,4 +1,4 @@
-import { getEditorState } from "./common";
+import { generateSnippet, getEditorState } from "./common";
 import { COMMENT_TYPES, DECORATIONS } from "./constants";
 import { Decorator, Stage } from "./types";
 
@@ -84,7 +84,7 @@ function onButtonBarClick(e: MouseEvent) {
       renderDecorationButtons(buttonBar, label);
     } else {
       // No decorations, just insert label
-      const snippet = `**${label}:** `;
+      const snippet = generateSnippet(label, Decorator.NONE);
       updateCommentPrefix(snippet);
       renderLabelButtons(buttonBar, selectedLabel); // Re-render with active label
     }
@@ -97,7 +97,7 @@ function onButtonBarClick(e: MouseEvent) {
     if (!decoration || !selectedLabel) return;
     
     selectedDecoration = decoration;
-    const snippet = selectedDecoration !== Decorator.NONE ? `**${selectedLabel} ${selectedDecoration}:** ` : `**${selectedLabel}:** `;
+    const snippet = generateSnippet(selectedLabel, selectedDecoration as Decorator);
     updateCommentPrefix(snippet);
     renderDecorationButtons(buttonBar, selectedLabel, selectedDecoration);
     return;

--- a/src/buttonHandler.ts
+++ b/src/buttonHandler.ts
@@ -277,9 +277,7 @@ function handleFocusIn(e: FocusEvent) {
   }
 
   // Don't show a bar if one is already active or another flow is in progress
-  if (buttonBar || currentStage !== Stage.INACTIVE) {
-    checkSelectedOptions(target);
-    
+  if (buttonBar || currentStage !== Stage.INACTIVE) {    
     return;
   }
 

--- a/src/buttonHandler.ts
+++ b/src/buttonHandler.ts
@@ -1,6 +1,6 @@
 import { getEditorState } from "./common";
 import { COMMENT_TYPES, DECORATIONS } from "./constants";
-import { Stage } from "./types";
+import { Decorator, Stage } from "./types";
 
 let activeEditor: HTMLTextAreaElement | HTMLElement | null;
 let currentStage: Stage;
@@ -95,9 +95,9 @@ function onButtonBarClick(e: MouseEvent) {
   if (target.matches(".cc-button[data-decoration]")) {
     const decoration = target.dataset.decoration;
     if (!decoration || !selectedLabel) return;
-
+    
     selectedDecoration = decoration;
-    const snippet = `**${selectedLabel} ${decoration}:** `;
+    const snippet = selectedDecoration !== Decorator.NONE ? `**${selectedLabel} ${selectedDecoration}:** ` : `**${selectedLabel}:** `;
     updateCommentPrefix(snippet);
     renderDecorationButtons(buttonBar, selectedLabel, selectedDecoration);
     return;
@@ -278,6 +278,8 @@ function handleFocusIn(e: FocusEvent) {
 
   // Don't show a bar if one is already active or another flow is in progress
   if (buttonBar || currentStage !== Stage.INACTIVE) {
+    checkSelectedOptions(target);
+    
     return;
   }
 
@@ -297,6 +299,8 @@ function handleFocusIn(e: FocusEvent) {
   renderLabelButtons(buttonBar);
   buttonBar.addEventListener("click", onButtonBarClick);
   setupCleanupListeners();
+
+  checkSelectedOptions(target);
 }
 
 function handleInput(e: Event) {
@@ -304,6 +308,10 @@ function handleInput(e: Event) {
   const target = e.target as HTMLTextAreaElement | HTMLElement;
   if (!target) return;
 
+  checkSelectedOptions(target);
+}
+
+function checkSelectedOptions(target: HTMLTextAreaElement | HTMLElement) {
   const { text } = getEditorState(target);
   snippet = text;
 
@@ -318,7 +326,7 @@ function handleInput(e: Event) {
     // Validate label exists in COMMENT_TYPES
     const commentType = COMMENT_TYPES.find((c) => c.label === label);
     const decorationType = commentType?.decorations?.find(
-      (d) => d === `(${decoration})` // Regex will match non-blocking instead of (non-blocking)
+      (d) => !decoration.length ? d === Decorator.NONE : d === `(${decoration})` // Regex will match non-blocking instead of (non-blocking)
     );
     if (commentType) {
       selectedLabel = label;

--- a/src/common.ts
+++ b/src/common.ts
@@ -28,5 +28,5 @@ export function getEditorState(
 }
 
 export function generateSnippet(type: string, decorator: Decorator): string {
-  return !decorator.length || decorator === Decorator.NONE ? `**${type}:**` : `**${type} ${decorator}:**`;
+  return !decorator.length || decorator === Decorator.NONE ? `**${type}:** ` : `**${type} ${decorator}:** `;
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,4 +1,4 @@
-import { EditorState } from "./types";
+import { Decorator, EditorState } from "./types";
 
 export function getEditorState(
   editor: HTMLTextAreaElement | HTMLElement
@@ -25,4 +25,8 @@ export function getEditorState(
       cursorPosition: textareaElement.selectionStart,
     };
   }
+}
+
+export function generateSnippet(type: string, decorator: Decorator): string {
+  return !decorator.length || decorator === Decorator.NONE ? `**${type}:**` : `**${type} ${decorator}:**`;
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,56 +1,56 @@
-import { CommentType, Decoration } from "./types";
+import { CommentType, Decoration, Decorator, } from "./types";
 
 export const COMMENT_TYPES: CommentType[] = [
   {
-    label: "issue",
+    label: "Issue",
     description: "A problem or bug.",
-    decorations: ["(non-blocking)", "(blocking)", "(if-minor)"],
+    decorations: [Decorator.NONE, Decorator.BLOCKING, Decorator.NON_BLOCKING, Decorator.IF_MINOR],
   },
   {
-    label: "question",
+    label: "Question",
     description: "A question about the code.",
-    decorations: ["(blocking)"],
+    decorations: [Decorator.NONE, Decorator.BLOCKING, Decorator.NON_BLOCKING],
   },
   {
-    label: "suggestion",
+    label: "Suggestion",
     description: "A suggestion for improvement.",
-    decorations: ["(if-minor)"],
+    decorations: [Decorator.NONE, Decorator.BLOCKING, Decorator.NON_BLOCKING, Decorator.IF_MINOR],
   },
   {
-    label: "praise",
+    label: "Praise",
     description: "Praise for well-written code.",
     decorations: [],
   },
   {
-    label: "nitpick",
+    label: "Nitpick",
     description: "A minor, non-critical style issue.",
-    decorations: ["(if-minor)"],
+    decorations: [],
   },
   {
-    label: "thought",
+    label: "Thought",
     description: "A thought or exploration of an idea.",
     decorations: [],
   },
   {
-    label: "chore",
+    label: "Chore",
     description: "A routine task or maintenance.",
-    decorations: ["(if-minor)"],
+    decorations: [Decorator.NONE, Decorator.IF_MINOR],
   },
 ];
 
 export const DECORATIONS: Decoration[] = [
-  { label: "none", description: "Do not add any decoration." },
+  { label: Decorator.NONE, description: "Do not add any decoration." },
   {
-    label: "(non-blocking)",
+    label: Decorator.NON_BLOCKING,
     description: "Should not prevent the subject from being accepted.",
   },
   {
-    label: "(blocking)",
+    label: Decorator.BLOCKING,
     description:
       "Should prevent the subject from being accepted until resolved.",
   },
   {
-    label: "(if-minor)",
+    label: Decorator.IF_MINOR,
     description: "Resolve only if the changes end up being minor or trivial.",
   },
 ];

--- a/src/inputHandler.ts
+++ b/src/inputHandler.ts
@@ -1,4 +1,4 @@
-import { getEditorState } from "./common";
+import { generateSnippet, getEditorState } from "./common";
 import { COMMENT_TYPES, DECORATIONS } from "./constants";
 import { CommentType, Decoration, Stage, Decorator } from "./types";
 
@@ -48,12 +48,7 @@ function onPressEnter(): void {
     }
   } else if (currentStage === Stage.SELECTING_DECORATION) {
     const selectedDecoration = selectedItem.dataset.label || "";
-    let snippet: string;
-    if (selectedDecoration === Decorator.NONE) {
-      snippet = `**${selectedLabel}:** `;
-    } else {
-      snippet = `**${selectedLabel} ${selectedDecoration}:** `;
-    }
+    let snippet = generateSnippet(selectedLabel, selectedDecoration as Decorator);
     insertSnippet(snippet);
   }
 }

--- a/src/inputHandler.ts
+++ b/src/inputHandler.ts
@@ -118,6 +118,7 @@ function insertSnippet(snippet: string): void {
     textareaElement.scrollTop = 0;
     textareaElement.focus();
     textareaElement.setSelectionRange(newCursorPos, newCursorPos, "forward");
+    textareaElement.dispatchEvent(new Event("input", { bubbles: true }));
   }
 
   cleanup();

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -47,6 +47,7 @@
 }
 
 .type-badge {
+  cursor: pointer;
   background-color: #a3c1d1;
   color: var(--c-text-color);
   padding: 3px 8px;

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,3 +20,10 @@ export enum Stage {
   SELECTING_DECORATION = 2,
   BUTTON_UI,
 }
+
+export enum Decorator {
+  NONE = "_",
+  BLOCKING = "(blocking)",
+  NON_BLOCKING = "(non-blocking)",
+  IF_MINOR = "(if-minor)",
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,7 +22,7 @@ export enum Stage {
 }
 
 export enum Decorator {
-  NONE = "_",
+  NONE = "none",
   BLOCKING = "(blocking)",
   NON_BLOCKING = "(non-blocking)",
   IF_MINOR = "(if-minor)",


### PR DESCRIPTION
# Changes

- **Consistent `DECORATIONS` typing**: Replaced raw strings with a strongly-typed enum to improve type safety and maintainability.

- **Label badge now interactive**: Added functionality to allow users to click the selected label badge to return to label selection and choose a different comment type.

- **Change ESC behavior:** Pressing Escape now properly exits suggestion mode without injecting a snippet (previously it inserted the selected label).

- **Fixed macOS "blue underline" Enter issue**: Resolved double-execution of `onPressEnter()` caused by macOS autocorrect/autocompose committing on Enter. This prevents unintended snippet insertion.

# Demo Video

BEFORE

https://github.com/user-attachments/assets/00b97c6f-40f5-4f51-b48c-ec93d83ac9ac


https://github.com/user-attachments/assets/3c08d14c-6433-4f5c-91a9-798bad167412





AFTER

https://github.com/user-attachments/assets/b364bda7-436c-4e34-9b1d-effeeb55be96



https://github.com/user-attachments/assets/df3b0d68-27bb-493e-a3b6-5cf974ac2447



