### PR TITLE
Fix: ensure consistent keydown capture and focus behavior in new comment UI

### DIFF
--- a/src/buttonHandler.ts
+++ b/src/buttonHandler.ts
@@ -299,6 +299,8 @@ function handleFocusIn(e: FocusEvent) {
   setupCleanupListeners();
 
   checkSelectedOptions(target);
+
+  activeEditor.focus();
 }
 
 function handleInput(e: Event) {

--- a/src/inputHandler.ts
+++ b/src/inputHandler.ts
@@ -265,6 +265,6 @@ export function setup() {
   initState();
 
   document.addEventListener("input", handleInput);
-  document.addEventListener("keydown", handleKeyDown);
+  document.addEventListener("keydown", handleKeyDown, true);
   document.addEventListener("click", handleClickOutside);
 }


### PR DESCRIPTION
# Changes

- Fixes keydown capture issue by registering the keydown listener in the capture phase, ensuring it detects key inputs (like `!` + `enter`) reliably across different UI setups.

- Improves UX by ensuring the textarea is focused immediately after injecting the comment editor wrapper when triggered via the extension button. -> No need to double click to focus to be able to edit text

# Demo Video

BEFORE

https://github.com/user-attachments/assets/fa4b0da9-3f3e-47e7-b841-85059eaadf9a


https://github.com/user-attachments/assets/2e66c2e7-dc9a-4048-a6d0-7a3f74b6735e



AFTER

https://github.com/user-attachments/assets/64e7b2a2-adc8-4269-93a8-3156289cebac


https://github.com/user-attachments/assets/da8b6b51-4d8c-4ab9-acb8-d7462fdea34c


