### PR TITLE
Fix: Fix extension not working when navigating pages

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,9 +14,13 @@
   },
   "content_scripts": [
     {
-      "matches": ["<all_urls>"],
+      "matches": [
+        "https://github.com/*",
+        "https://*.github.com/*"
+      ],
       "css": ["styles.css"],
-      "js": ["main.js"]
+      "js": ["main.js"],
+      "run_at": "document_idle"
     }
   ],
   "action": {

--- a/src/buttonHandler.ts
+++ b/src/buttonHandler.ts
@@ -357,6 +357,11 @@ function checkSelectedOptions(target: HTMLTextAreaElement | HTMLElement) {
 export function setup() {
   initState();
 
+  // Remove existing event listeners to avoid duplicates
+  document.removeEventListener("focusin", handleFocusIn, true);
+  document.removeEventListener("input", handleInput);
+
+  // Initialize event listeners
   document.addEventListener("focusin", handleFocusIn, true);
   document.addEventListener("input", handleInput);
 }

--- a/src/inputHandler.ts
+++ b/src/inputHandler.ts
@@ -264,6 +264,12 @@ function handleInput(e: Event) {
 export function setup() {
   initState();
 
+  // Remove existing event listeners to avoid duplicates
+  document.removeEventListener("input", handleInput);
+  document.removeEventListener("keydown", handleKeyDown, true);
+  document.removeEventListener("click", handleClickOutside);
+
+  // Initialize event listeners
   document.addEventListener("input", handleInput);
   document.addEventListener("keydown", handleKeyDown, true);
   document.addEventListener("click", handleClickOutside);

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,15 +14,26 @@ function checkIfGithubPullRequest() {
 
 // Initialize the extension based on the user's saved setting.
 chrome.storage.sync.get({ triggerMode: "buttons" }, (data) => {
-  // Only initialize if we're on a GitHub pull request page
-  if (checkIfGithubPullRequest()) {
-    if (data.triggerMode === "both") {
-      setupButtonHandler();
-      setupInputHandler();
-    } else if (data.triggerMode === "buttons") {
-      setupButtonHandler();
-    } else if (data.triggerMode === "trigger") {
-      setupInputHandler();
+  let lastUrl = '';
+
+  const observer = new MutationObserver(() => {
+    const currentUrl = location.pathname;
+    if (currentUrl === lastUrl) return;
+
+    lastUrl = currentUrl;
+
+    // Only initialize if we're on a GitHub pull request page
+    if (checkIfGithubPullRequest()) {
+      if (data.triggerMode === "both") {
+        setupButtonHandler();
+        setupInputHandler();
+      } else if (data.triggerMode === "buttons") {
+        setupButtonHandler();
+      } else if (data.triggerMode === "trigger") {
+        setupInputHandler();
+      }
     }
-  }
+  });
+
+  observer.observe(document.body, { childList: true, subtree: true });
 });


### PR DESCRIPTION
# Changes
- Update manifest config file to make the extension code triggered on github page only
- Add observer to keep track on path changes and re-setup ->  Fix extension not working when navigating pages

# Demo video


https://github.com/user-attachments/assets/74510b97-ff50-4a05-bbea-bfb98ef494dd


https://github.com/user-attachments/assets/676c2da2-726e-40d4-8820-d1edbad0dda4

