### PR TITLE
Enhancement: enhance snippet injection for both setting

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -28,10 +28,53 @@ export function getEditorState(
   }
 }
 
+export function insertSnippet(activeEditor: HTMLTextAreaElement | HTMLElement, snippet: string, triggerIndex?: number): void {
+  const { text, cursorPosition } = getEditorState(activeEditor);
+
+  const match = text.match(/^\*\*.*:\**/);
+  const snippetRange = {
+    start: 0,
+    end: match ? match[0].length : 0
+  }
+  if (match && /\s/.test(text.charAt(match[0].length))) snippet = snippet.trim()
+
+  const textareaElement = activeEditor as HTMLTextAreaElement;
+  triggerIndex = triggerIndex ?? cursorPosition;
+
+  textareaElement.focus();
+  textareaElement.setSelectionRange(cursorPosition, cursorPosition)
+
+  const validateCmd = document.execCommand('insertText', false, '');
+  if (validateCmd) {
+    if (triggerIndex !== cursorPosition) {
+      textareaElement.setSelectionRange(triggerIndex, cursorPosition);
+      document.execCommand('delete', false);
+    }
+    textareaElement.setSelectionRange(snippetRange.start, snippetRange.end)
+    document.execCommand('insertText', false, snippet);
+  } else {
+    // Fallback for browsers that do not support execCommand
+    const textBefore = text.substring(snippetRange.end, triggerIndex);
+    const textAfter = text.substring(cursorPosition);
+    textareaElement.value = snippet + textBefore + textAfter;
+
+    const newCursorPos = snippet.length;
+    textareaElement.setSelectionRange(newCursorPos, newCursorPos, "forward");
+  }
+
+  textareaElement.scrollTop = 0;
+  textareaElement.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
 export function generateSnippet(type: string, decorator: Decorator): string {
   return !decorator.length || decorator === Decorator.NONE ? `**${type}:** ` : `**${type} ${decorator}:** `;
 }
 
 export function commentTypesInjected(text: string): boolean {
   return COMMENT_TYPES.some(({ label }) => text.startsWith(`**${label}`));
+}
+
+export function handleGlobalListener<T extends Event>(e: T, executor: (_: T) => void): void {
+  const target = e.target as HTMLElement;
+  if (target && !target.isContentEditable) executor(e);
 }


### PR DESCRIPTION
# Changes

- Remove `isContentEditable` support since we only need PR comments/discussions support
- Move snippet insertion from text override programatically to `execCommand` (like user interaction) -> hook into undo stack to make it work properly
- Centralize snippet insertion logic for both settings

# Note

Location | Editable Type | Notes
-- | -- | --
GitHub Discussions (new post or reply) | contenteditable | Rich text editor
Issue descriptions (initial post) | contenteditable | Uses markdown preview + toolbar
PR descriptions (initial comment when opening) | contenteditable | Same as issue body
New comment in Projects (Beta) | contenteditable | Uses the new comment box design
Pull Request review comments | <textarea> | When reviewing code line-by-line
Inline code comments (in file diffs) | <textarea> | Classic GitHub textarea
Standard comment boxes on issues/PRs | <textarea> | Simple markdown support
Commit comments | <textarea> | Also plain text

# Demo Video

BEFORE


https://github.com/user-attachments/assets/4da61ad1-5eb4-4cc7-b437-5d229e970c84




AFTER

https://github.com/user-attachments/assets/435e355e-8268-4dab-8a6e-f21e3c3973de



https://github.com/user-attachments/assets/dc4be3a7-8ff2-497b-bd8b-1db1c806a337

