### PR TITLE
Bug: Fix bug where textarea does not occupy 100% width.

### DIFF
--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -63,7 +63,10 @@
   display: flex;
   flex-direction: column;
   position: relative;
-  width: 'inherit';
+  width: 100%;
+  textarea {
+    box-sizing: border-box !important;
+  }
 }
 
 .cc-editor-enhanced {


### PR DESCRIPTION
## Description
The textarea isn’t occupying 100% width, as shown in the screenshot below.
<img width="702" height="302" alt="Screenshot 2025-07-15 at 22 31 33" src="https://github.com/user-attachments/assets/0f864284-a090-4008-8155-e84d1c542d41" />

## Demo/Screenshot
<img width="630" height="284" alt="image" src="https://github.com/user-attachments/assets/58d8f479-ed57-4b6c-bf62-e3c6345031c1" />
