### PR TITLE
Enhancement: enhance init extension behavior

### DIFF
--- a/src/buttonHandler.ts
+++ b/src/buttonHandler.ts
@@ -307,10 +307,6 @@ function checkSelectedOptions(target: HTMLTextAreaElement | HTMLElement) {
 export function setup() {
   initState();
 
-  // Remove existing event listeners to avoid duplicates
-  document.removeEventListener("focusin", (e) => handleGlobalListener(e, handleFocusIn), true);
-  document.removeEventListener("input", (e) => handleGlobalListener(e, handleInput));
-
   // Initialize event listeners
   document.addEventListener("focusin", (e) => handleGlobalListener(e, handleFocusIn), true);
   document.addEventListener("input", (e) => handleGlobalListener(e, handleInput));

--- a/src/common.ts
+++ b/src/common.ts
@@ -74,7 +74,20 @@ export function commentTypesInjected(text: string): boolean {
   return COMMENT_TYPES.some(({ label }) => text.startsWith(`**${label}`));
 }
 
+function checkIfGithubPullRequest() {
+  if (!window || !window.location) return false;
+  const hostname = window.location.hostname;
+  const pathname = window.location.pathname;
+
+  const isGitHub = hostname === "github.com" || hostname.includes("github");
+  const isPullRequest = /\/[^\/]+\/[^\/]+\/pull\/\d+/.test(pathname);
+
+  return isGitHub && isPullRequest;
+}
+
 export function handleGlobalListener<T extends Event>(e: T, executor: (_: T) => void): void {
+  if (!checkIfGithubPullRequest()) return;
+  
   const target = e.target as HTMLElement;
   if (target && !target.isContentEditable) executor(e);
 }

--- a/src/inputHandler.ts
+++ b/src/inputHandler.ts
@@ -235,19 +235,6 @@ function handleInput(e: Event) {
 export function setup() {
   initState();
 
-  // Remove existing event listeners to avoid duplicates
-  document.removeEventListener("input", (e) =>
-    handleGlobalListener(e, handleInput)
-  );
-  document.removeEventListener(
-    "keydown",
-    (e) => handleGlobalListener(e, handleKeyDown),
-    true
-  );
-  document.removeEventListener("click", (e) =>
-    handleGlobalListener(e, handleClickOutside)
-  );
-
   // Initialize event listeners
   document.addEventListener("input", (e) =>
     handleGlobalListener(e, handleInput)

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,39 +1,14 @@
 import { setup as setupInputHandler } from "./inputHandler";
 import { setup as setupButtonHandler } from "./buttonHandler";
 
-function checkIfGithubPullRequest() {
-  if (!window || !window.location) return false;
-  const hostname = window.location.hostname;
-  const pathname = window.location.pathname;
-
-  const isGitHub = hostname === "github.com" || hostname.includes("github");
-  const isPullRequest = /\/[^\/]+\/[^\/]+\/pull\/\d+/.test(pathname);
-
-  return isGitHub && isPullRequest;
-}
-
 // Initialize the extension based on the user's saved setting.
 chrome.storage.sync.get({ triggerMode: "buttons" }, (data) => {
-  let lastUrl = '';
-
-  const observer = new MutationObserver(() => {
-    const currentUrl = location.pathname;
-    if (currentUrl === lastUrl) return;
-
-    lastUrl = currentUrl;
-
-    // Only initialize if we're on a GitHub pull request page
-    if (checkIfGithubPullRequest()) {
-      if (data.triggerMode === "both") {
-        setupButtonHandler();
-        setupInputHandler();
-      } else if (data.triggerMode === "buttons") {
-        setupButtonHandler();
-      } else if (data.triggerMode === "trigger") {
-        setupInputHandler();
-      }
+  if (data.triggerMode === "both") {
+      setupButtonHandler();
+      setupInputHandler();
+    } else if (data.triggerMode === "buttons") {
+      setupButtonHandler();
+    } else if (data.triggerMode === "trigger") {
+      setupInputHandler();
     }
-  });
-
-  observer.observe(document.body, { childList: true, subtree: true });
 });


### PR DESCRIPTION
# Context

Currently, calling remove and readd listener on re-initialization can cause unexpected behavior when the listener is not properly removed -> can cause double listener issue.

**Solution**: Improve the behavior of the init extension, initialize the extension once and let the guard handler cover the non-github-PR site.

# Demo Video


https://github.com/user-attachments/assets/35b4e8e9-3796-4db8-a8f4-bf6e600ee327


