### PR TITLE
Df/make button UI only show in comment

### DIFF
--- a/src/inputHandler.ts
+++ b/src/inputHandler.ts
@@ -39,7 +39,7 @@ function onPressEnter(): void {
   if (currentStage === Stage.SELECTING_LABEL) {
     selectedLabel = selectedItem.dataset.label || "";
     currentStage = Stage.SELECTING_DECORATION;
-    activeEditor?.blur();
+    // Don't blur the editor - we need it to remain focused for keyboard events
 
     const decorations =
       COMMENT_TYPES.find((d) => d.label === selectedLabel)?.decorations || [];
@@ -50,8 +50,10 @@ function onPressEnter(): void {
     if (decorationsWithDescription.length > 0) {
       showSuggestions(decorationsWithDescription);
     } else {
-      selectedItem.dataset.label = Decorator.NONE;
-      onPressEnter();
+      // No decorations available, directly insert snippet with no decoration
+      let snippet = generateSnippet(selectedLabel, Decorator.NONE);
+      if (activeEditor) insertSnippet(activeEditor, snippet, triggerIndex);
+      cleanup();
     }
   } else if (currentStage === Stage.SELECTING_DECORATION) {
     const selectedDecoration = selectedItem.dataset.label || "";


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->
- Update isCommentTextarea() to exclude PR description/title edit areas
- Fix keyboard event handling in decoration selection stage
- Remove activeEditor.blur() that was breaking Enter key functionality
- Ensure extension only appears in legitimate comment boxes

## Demo
<!-- Add screenshots, GIFs, or videos demonstrating the changes -->
<!-- You can drag and drop images/GIFs directly into this section -->

## Checklist
<!-- Mark completed items with [x] -->

- [x] I have tested these changes locally
- [x] I have updated the documentation (if necessary)
- [x] I have added a demo/screenshot/GIF showing the changes